### PR TITLE
Remove Sidebar from Vehicle Archive Pages

### DIFF
--- a/archive-post.php
+++ b/archive-post.php
@@ -48,12 +48,6 @@ get_header();
 
 		</main><!-- #main -->
 
-		<?php
-		if ( is_post_type_archive() || is_tax() ) {
-			get_sidebar();
-		}
-		?>
-
 	</div><!-- #primary -->
 
 <?php

--- a/archive.php
+++ b/archive.php
@@ -7,11 +7,7 @@
  * @package SVINE
  */
 
-if ( is_post_type_archive() || is_tax('vehicle_type') ) {
-	$max_count = 19;
-} else {
-	$max_count = 12;
-}
+$max_count = 24;
 
 get_header();
 ?>
@@ -39,20 +35,6 @@ get_header();
 
 				if ( $count == $max_count ) {
 					break;
-				} elseif ( $count == 0 && ( is_post_type_archive() || is_tax('vehicle_type') ) ) {
-			?>
-				<article <?php post_class('card'); ?>>
-					<a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-						<?php
-						svine_post_thumbnail( 'full' );
-
-						the_title( '<h3 class="h2">', '</h3>' );
-						?>
-					</a>
-				</article>
-			<?php
-				$count++;
-
 				} else {
 					get_template_part( 'template-parts/content', 'archive' );
 					$count++;
@@ -74,12 +56,6 @@ get_header();
 		?>
 
 		</main><!-- #main -->
-
-		<?php
-		if ( is_post_type_archive() || is_tax('vehicle_type') ) {
-			get_sidebar();
-		}
-		?>
 
 	</div><!-- #primary -->
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -14,3 +14,14 @@ function svine_pingback_header() {
 	}
 }
 add_action( 'wp_head', 'svine_pingback_header' );
+
+/**
+ * Alphabetize archive page posts
+ */
+function svine_modify_query_order( $query ) {
+	if ( $query->is_archive() ) {
+		$query->set( 'orderby', 'title' );
+		$query->set( 'order', 'ASC' );
+	}
+}
+add_action( 'pre_get_posts', 'svine_modify_query_order' );

--- a/sass/layout/_content-sidebar.scss
+++ b/sass/layout/_content-sidebar.scss
@@ -5,9 +5,7 @@
 	}
 
 	.blog,
-	.single-post,
-	.post-type-archive,
-	.tax-vehicle_type {
+	.single-post {
 
 		.page-header {
 			width: 100%;
@@ -29,5 +27,4 @@
 		}
 
 	}
-
 }

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -113,13 +113,9 @@
 }
 
 
-// Vehicle & Taxonomy Archives
-
-.post-type-archive-vehicle,
-.tax-vehicle_type,
-.tax-model,
-.tax-location,
-.tag {
+// Vehicle Archives
+// (all archive pages except Category, which we only have for Posts)
+.archive:not(.category) {
 
 	.site-main {
 		align-content: flex-start;
@@ -130,59 +126,29 @@
 
 	.card {
 		text-align: center;
-	}
-}
 
-// Vehicle & Vehicle-Type Archives
-.post-type-archive-vehicle,
-.tax-vehicle_type {
-
-	.card {
-
-		h3 {
-			margin-top: $padding;
+		@media screen and ($medium-down) {
+			&:nth-of-type(2n) {
+				margin-right: 0;
+			}
 		}
 
 		@media screen and ($medium-up) {
+			margin-right: $padding;
 			width: calc(50% - #{($padding)});
+		}
 
-			&:first-of-type {
-				width: 100%;
-			}
+		@media screen and ($large-up) {
+			margin-right: $padding * 2;
+			width: calc(33.334% - #{($padding * 2)});
 
-			&:nth-of-type(2n + 2) {
-				margin-right: $padding * 2;
+			&:nth-of-type(3n) {
+				margin-right: 0;
 			}
 		}
 	}
 }
 
-
-// Other Vehicle Taxonomy Archives
-.tax-model .card,
-.tax-location .card,
-.tag .card {
-
-	@media screen and ($medium-down) {
-		&:nth-of-type(2n) {
-			margin-right: 0;
-		}
-	}
-
-	@media screen and ($medium-up) {
-		margin-right: $padding;
-		width: calc(50% - #{($padding)});
-	}
-
-	@media screen and ($large-up) {
-		margin-right: $padding * 2;
-		width: calc(33.334% - #{($padding * 2)});
-
-		&:nth-of-type(3n) {
-			margin-right: 0;
-		}
-	}
-}
 
 // Search Results
 .search-results {


### PR DESCRIPTION
now all Vehicle-related archive pages will have a three-column grid layout, with no sidebar. This is applied to all archive pages except Category, which is a taxonomy we happen to only use on blog/Posts.